### PR TITLE
Fix failure to detect tasks failing to start

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,8 @@ async function run() {
         (task) => task.stopCode === "TaskFailedToStart"
       );
 
+      core.debug(unableToStart, containerExitedWithError);
+
       if (unableToStart) {
         core.setFailed("Some containers failed to start");
       }

--- a/index.js
+++ b/index.js
@@ -66,8 +66,6 @@ async function run() {
         (task) => task.stopCode === "TaskFailedToStart"
       );
 
-      core.debug(unableToStart, containerExitedWithError);
-
       if (unableToStart) {
         core.setFailed("Some containers failed to start");
       }

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ async function run() {
         (task) => task.stopCode === "TaskFailedToStart"
       );
 
-      console.log(unableToStart, containerExitedWithError);
+      core.debug(unableToStart, containerExitedWithError);
 
       if (unableToStart) {
         core.setFailed("Some containers failed to start");

--- a/index.js
+++ b/index.js
@@ -58,11 +58,19 @@ async function run() {
 
       core.debug(JSON.stringify(waitResult, null, 2));
 
-      const hasFailures = waitResult.tasks.some((task) =>
+      const containerExitedWithError = waitResult.tasks.some((task) =>
         task.containers.some((container) => !!container.exitCode)
       );
 
-      if (hasFailures) {
+      const unableToStart = waitResult.tasks.some(
+        (task) => task.stopCode === "TaskFailedToStart"
+      );
+
+      if (unableToStart) {
+        core.setFailed("Some containers failed to start");
+      }
+
+      if (containerExitedWithError) {
         core.setFailed("Some containers exited with non-zero exit codes");
       }
     }

--- a/index.js
+++ b/index.js
@@ -66,6 +66,8 @@ async function run() {
         (task) => task.stopCode === "TaskFailedToStart"
       );
 
+      console.log(unableToStart, containerExitedWithError);
+
       if (unableToStart) {
         core.setFailed("Some containers failed to start");
       }


### PR DESCRIPTION
https://github.com/synapsestudios/amazon-ecs-run-task/issues/5

- Add `unableToStart` detection
- Rename variable to make more readable